### PR TITLE
Bump to CoreOS 1053.2.0

### DIFF
--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -47,34 +47,34 @@
   "Mappings": {
     "RegionToAmi": {
       "ap-northeast-1": {
-        "stable": "ami-84e0c7ea"
+        "stable": "ami-802dcde1"
       },
       "ap-southeast-1": {
-        "stable": "ami-da67a0b9"
+        "stable": "ami-4c97462f"
       },
       "ap-southeast-2": {
-        "stable": "ami-f35b0590"
+        "stable": "ami-55f6d936"
       },
       "eu-central-1": {
-        "stable": "ami-fdd4c791"
+        "stable": "ami-3b1cf054"
       },
       "eu-west-1": {
-        "stable": "ami-55d20b26"
+        "stable": "ami-2a118659"
       },
       "sa-east-1": {
-        "stable": "ami-154af179"
+        "stable": "ami-ee1b9382"
       },
       "us-east-1": {
-        "stable": "ami-37bdc15d"
+        "stable": "ami-3cf20751"
       },
       "us-gov-west-1": {
-        "stable": "ami-05bc0164"
+        "stable": "ami-9041fef1"
       },
       "us-west-1": {
-        "stable": "ami-652c5505"
+        "stable": "ami-61e99101"
       },
       "us-west-2": {
-        "stable": "ami-f5bc4e95"
+        "stable": "ami-c30af5a3"
       }
     },
     "NATAmi" : {

--- a/gen/installer/bash.py
+++ b/gen/installer/bash.py
@@ -312,8 +312,7 @@ function check_all() {
             print version
         }
     ')
-    # CoreOS stable as of Aug 2015 has 1.6.2
-    check docker 1.6 "$docker_version"
+    check docker 1.10 "$docker_version"
 
     check curl
     check bash


### PR DESCRIPTION
  -Talked to Seb, and he said that CoreOS 1053.2.0 is the first release without
    the systemd sudo bug. We can rely on it being released by EA / GA into something
    more stable
  -Made the installer check for Docker 1.10